### PR TITLE
Add support for psr/cache v2 and v3

### DIFF
--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,9 @@
   ],
   "license": "LGPL-3.0-only",
   "require": {
+    "php": ">=8.0.0",
     "jord-jd/do-file-cache": "^5.0",
-    "psr/cache": "^1.0"
+    "psr/cache": "^1.0 || ^2.0 || ^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.6"

--- a/src/CacheItem.php
+++ b/src/CacheItem.php
@@ -18,12 +18,12 @@ class CacheItem implements CacheItemInterface
         $this->value = $value;
     }
 
-    public function getKey()
+    public function getKey(): string
     {
         return $this->key;
     }
 
-    public function get()
+    public function get(): mixed
     {
         if ($this->isHit()===false) {
             return null;
@@ -37,7 +37,7 @@ class CacheItem implements CacheItemInterface
         return $this->expires;
     }
 
-    public function isHit()
+    public function isHit(): bool
     {
         if ($this->expires !== 0 && $this->expires < time()) {
             return false;
@@ -46,7 +46,7 @@ class CacheItem implements CacheItemInterface
         return $this->value !== false;
     }
 
-    public function set($value)
+    public function set($value): static
     {
         if ($this->isDeferred) {
             $this->deferredValue = $value;
@@ -66,7 +66,7 @@ class CacheItem implements CacheItemInterface
         return $this;
     }
 
-    public function expiresAt($expiration)
+    public function expiresAt($expiration): static
     {
         if ($expiration==null) {
             $this->expires = 0;
@@ -76,7 +76,7 @@ class CacheItem implements CacheItemInterface
         return $this;
     }
 
-    public function expiresAfter($time)
+    public function expiresAfter($time): static
     {
         if (is_integer($time)) {
             $this->expires = time()+$time;

--- a/src/CacheItem.php
+++ b/src/CacheItem.php
@@ -25,7 +25,7 @@ class CacheItem implements CacheItemInterface
 
     public function get(): mixed
     {
-        if ($this->isHit()===false) {
+        if ($this->isHit() === false) {
             return null;
         }
 
@@ -50,10 +50,12 @@ class CacheItem implements CacheItemInterface
     {
         if ($this->isDeferred) {
             $this->deferredValue = $value;
-            return;
+
+            return $this;
         }
 
         $this->value = $value;
+
         return $this;
     }
 
@@ -63,25 +65,27 @@ class CacheItem implements CacheItemInterface
         if ($this->deferredValue) {
             $this->value = $this->deferredValue;
         }
+
         return $this;
     }
 
     public function expiresAt($expiration): static
     {
-        if ($expiration==null) {
+        if ($expiration == null) {
             $this->expires = 0;
         } else {
             $this->expires = $expiration->getTimestamp();
         }
+
         return $this;
     }
 
     public function expiresAfter($time): static
     {
         if (is_integer($time)) {
-            $this->expires = time()+$time;
+            $this->expires = time() + $time;
         }
+
         return $this;
     }
-
 }

--- a/src/CacheItemPool.php
+++ b/src/CacheItemPool.php
@@ -37,7 +37,7 @@ class CacheItemPool implements CacheItemPoolInterface
 
     }
 
-    public function getItem($key)
+    public function getItem($key): CacheItemInterface
     {
         $this->sanityCheckKey($key);
 
@@ -48,7 +48,7 @@ class CacheItemPool implements CacheItemPoolInterface
         return new CacheItem($key, $this->doFileCache->get($key));
     }
 
-    public function getItems(array $keys = [])
+    public function getItems(array $keys = []): iterable
     {
         $results = [];
 
@@ -59,20 +59,20 @@ class CacheItemPool implements CacheItemPoolInterface
         return $results;
     }
 
-    public function hasItem($key)
+    public function hasItem($key): bool
     {
         $this->sanityCheckKey($key);
 
         return $this->getItem($key)->isHit();
     }
 
-    public function clear()
+    public function clear(): bool
     {
         $this->deferredItems = [];
         return $this->doFileCache->flush();
     }
 
-    public function deleteItem($key)
+    public function deleteItem($key): bool
     {
         $this->sanityCheckKey($key);
 
@@ -86,7 +86,7 @@ class CacheItemPool implements CacheItemPoolInterface
         return true;
     }
 
-    public function deleteItems(array $keys)
+    public function deleteItems(array $keys): bool
     {
 
 
@@ -97,18 +97,18 @@ class CacheItemPool implements CacheItemPoolInterface
         return true;
     }
 
-    public function save(CacheItemInterface $item)
+    public function save(CacheItemInterface $item): bool
     {
         return $this->doFileCache->set($item->getKey(), $item->get(), $item->getExpires());
     }
 
-    public function saveDeferred(CacheItemInterface $item)
+    public function saveDeferred(CacheItemInterface $item): bool
     {
         $this->deferredItems[$item->getKey()] = $item->prepareForSaveDeferred();
         return true;
     }
 
-    public function commit()
+    public function commit(): bool
     {
         foreach($this->deferredItems as $item) {
             $this->save($item);

--- a/src/CacheItemPool.php
+++ b/src/CacheItemPool.php
@@ -2,9 +2,9 @@
 
 namespace JordJD\DOFileCachePSR6;
 
-use Psr\Cache\CacheItemPoolInterface;
 use JordJD\DOFileCache\DOFileCache;
 use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
 
 class CacheItemPool implements CacheItemPoolInterface
 {
@@ -21,20 +21,19 @@ class CacheItemPool implements CacheItemPoolInterface
         return $this->doFileCache->changeConfig($config);
     }
 
-    private function sanityCheckKey($key) 
+    private function sanityCheckKey($key)
     {
         if (!is_string($key)) {
-            throw new CacheInvalidArgumentException;
+            throw new CacheInvalidArgumentException();
         }
 
         $invalidChars = ['{', '}', '(', ')', '/', '\\', '@', ':'];
 
-        foreach($invalidChars as $invalidChar) {
-            if (stripos($key, $invalidChar)!==false) {
-                throw new CacheInvalidArgumentException;
+        foreach ($invalidChars as $invalidChar) {
+            if (stripos($key, $invalidChar) !== false) {
+                throw new CacheInvalidArgumentException();
             }
         }
-
     }
 
     public function getItem($key): CacheItemInterface
@@ -52,7 +51,7 @@ class CacheItemPool implements CacheItemPoolInterface
     {
         $results = [];
 
-        foreach($keys as $key) {
+        foreach ($keys as $key) {
             $results[$key] = $this->getItem($key);
         }
 
@@ -69,6 +68,7 @@ class CacheItemPool implements CacheItemPoolInterface
     public function clear(): bool
     {
         $this->deferredItems = [];
+
         return $this->doFileCache->flush();
     }
 
@@ -78,6 +78,7 @@ class CacheItemPool implements CacheItemPoolInterface
 
         if (array_key_exists($key, $this->deferredItems)) {
             unset($this->deferredItems[$key]);
+
             return true;
         }
 
@@ -88,9 +89,7 @@ class CacheItemPool implements CacheItemPoolInterface
 
     public function deleteItems(array $keys): bool
     {
-
-
-        foreach($keys as $key) {
+        foreach ($keys as $key) {
             $this->deleteItem($key);
         }
 
@@ -105,15 +104,17 @@ class CacheItemPool implements CacheItemPoolInterface
     public function saveDeferred(CacheItemInterface $item): bool
     {
         $this->deferredItems[$item->getKey()] = $item->prepareForSaveDeferred();
+
         return true;
     }
 
     public function commit(): bool
     {
-        foreach($this->deferredItems as $item) {
+        foreach ($this->deferredItems as $item) {
             $this->save($item);
         }
         $this->deferredItems = [];
+
         return true;
     }
 


### PR DESCRIPTION
This PR adds returns types to the cache implementations and allows the usage of psr/cache v1|v2|v3. It requires at least PHP 8.0.

This PR also fixes a missing return in `CacheItem::set()` and fixes the code style.

Fixes #1 