### PR TITLE
Support PSR cache v2 and v3

### DIFF
--- a/.github/workflows/tests.yml
+++ b/.github/workflows/tests.yml
@@ -1,0 +1,24 @@
+name: Tests
+
+on:
+  push:
+  pull_request:
+
+jobs:
+  tests:
+    runs-on: ubuntu-latest
+    strategy:
+      fail-fast: false
+      matrix:
+        php: ['8.0', '8.5']
+        psr-cache: ['^1.0', '^2.0', '^3.0']
+
+    steps:
+      - uses: actions/checkout@v4
+      - uses: shivammathur/setup-php@v2
+        with:
+          php-version: ${{ matrix.php }}
+          coverage: none
+      - run: composer require --no-update "psr/cache:${{ matrix.psr-cache }}"
+      - run: composer update --prefer-dist --no-interaction
+      - run: vendor/bin/phpunit

--- a/composer.json
+++ b/composer.json
@@ -10,8 +10,9 @@
   ],
   "license": "LGPL-3.0-only",
   "require": {
+    "php": ">=8.0",
     "jord-jd/do-file-cache": "^5.0",
-    "psr/cache": "^1.0"
+    "psr/cache": "^1.0 || ^2.0 || ^3.0"
   },
   "require-dev": {
     "phpunit/phpunit": "^9.6"
@@ -26,7 +27,7 @@
   },
   "extra": {
     "branch-alias": {
-      "dev-master": "3.0-dev"
+      "dev-master": "4.0-dev"
     }
   }
 }

--- a/src/CacheItem.php
+++ b/src/CacheItem.php
@@ -2,6 +2,9 @@
 
 namespace JordJD\DOFileCachePSR6;
 
+use DateInterval;
+use DateTimeImmutable;
+use DateTimeInterface;
 use Psr\Cache\CacheItemInterface;
 
 class CacheItem implements CacheItemInterface
@@ -9,23 +12,23 @@ class CacheItem implements CacheItemInterface
     private $key;
     private $value;
     private $expires = 0;
-    public $isDeferred = false;
-    public $deferredValue;
+    private $hit;
 
-    public function __construct($key, $value)
+    public function __construct($key, $value, ?bool $hit = null)
     {
         $this->key = $key;
         $this->value = $value;
+        $this->hit = $hit ?? $value !== false;
     }
 
-    public function getKey()
+    public function getKey(): string
     {
         return $this->key;
     }
 
-    public function get()
+    public function get(): mixed
     {
-        if ($this->isHit()===false) {
+        if (!$this->isHit()) {
             return null;
         }
 
@@ -37,51 +40,53 @@ class CacheItem implements CacheItemInterface
         return $this->expires;
     }
 
-    public function isHit()
+    public function isHit(): bool
     {
-        if ($this->expires !== 0 && $this->expires < time()) {
+        if ($this->expires !== 0 && $this->expires <= time()) {
             return false;
         }
 
-        return $this->value !== false;
+        return $this->hit;
     }
 
-    public function set($value)
+    public function set($value): static
     {
-        if ($this->isDeferred) {
-            $this->deferredValue = $value;
-            return;
-        }
-
         $this->value = $value;
+        $this->hit = true;
+
         return $this;
     }
 
-    public function prepareForSaveDeferred()
+    public function prepareForSaveDeferred(): static
     {
-        $this->isDeferred = true;
-        if ($this->deferredValue) {
-            $this->value = $this->deferredValue;
-        }
         return $this;
     }
 
-    public function expiresAt($expiration)
+    public function expiresAt($expiration): static
     {
-        if ($expiration==null) {
+        if ($expiration === null) {
             $this->expires = 0;
-        } else {
+        } elseif ($expiration instanceof DateTimeInterface) {
             $this->expires = $expiration->getTimestamp();
+        } else {
+            throw new CacheInvalidArgumentException('Expiration must be a DateTimeInterface instance or null.');
         }
+
         return $this;
     }
 
-    public function expiresAfter($time)
+    public function expiresAfter($time): static
     {
-        if (is_integer($time)) {
-            $this->expires = time()+$time;
+        if ($time === null) {
+            $this->expires = 0;
+        } elseif (is_int($time)) {
+            $this->expires = time() + $time;
+        } elseif ($time instanceof DateInterval) {
+            $this->expires = (new DateTimeImmutable())->add($time)->getTimestamp();
+        } else {
+            throw new CacheInvalidArgumentException('Expiration must be an integer, DateInterval instance, or null.');
         }
+
         return $this;
     }
-
 }

--- a/src/CacheItemPool.php
+++ b/src/CacheItemPool.php
@@ -2,12 +2,14 @@
 
 namespace JordJD\DOFileCachePSR6;
 
-use Psr\Cache\CacheItemPoolInterface;
 use JordJD\DOFileCache\DOFileCache;
 use Psr\Cache\CacheItemInterface;
+use Psr\Cache\CacheItemPoolInterface;
 
 class CacheItemPool implements CacheItemPoolInterface
 {
+    private const VALUE_MARKER = '__jordjd_psr6_value';
+
     private $doFileCache;
     private $deferredItems = [];
 
@@ -21,23 +23,22 @@ class CacheItemPool implements CacheItemPoolInterface
         return $this->doFileCache->changeConfig($config);
     }
 
-    private function sanityCheckKey($key) 
+    private function sanityCheckKey($key)
     {
-        if (!is_string($key)) {
-            throw new CacheInvalidArgumentException;
+        if (!is_string($key) || $key === '') {
+            throw new CacheInvalidArgumentException('Cache keys must be non-empty strings.');
         }
 
         $invalidChars = ['{', '}', '(', ')', '/', '\\', '@', ':'];
 
-        foreach($invalidChars as $invalidChar) {
-            if (stripos($key, $invalidChar)!==false) {
-                throw new CacheInvalidArgumentException;
+        foreach ($invalidChars as $invalidChar) {
+            if (stripos($key, $invalidChar) !== false) {
+                throw new CacheInvalidArgumentException('Cache key contains a reserved character.');
             }
         }
-
     }
 
-    public function getItem($key)
+    public function getItem($key): CacheItemInterface
     {
         $this->sanityCheckKey($key);
 
@@ -45,34 +46,40 @@ class CacheItemPool implements CacheItemPoolInterface
             return $this->deferredItems[$key];
         }
 
-        return new CacheItem($key, $this->doFileCache->get($key));
+        $stored = $this->doFileCache->get($key);
+
+        if (is_array($stored) && array_key_exists(self::VALUE_MARKER, $stored)) {
+            return new CacheItem($key, $stored[self::VALUE_MARKER], true);
+        }
+
+        return new CacheItem($key, $stored);
     }
 
-    public function getItems(array $keys = [])
+    public function getItems(array $keys = []): iterable
     {
         $results = [];
 
-        foreach($keys as $key) {
+        foreach ($keys as $key) {
             $results[$key] = $this->getItem($key);
         }
 
         return $results;
     }
 
-    public function hasItem($key)
+    public function hasItem($key): bool
     {
         $this->sanityCheckKey($key);
 
         return $this->getItem($key)->isHit();
     }
 
-    public function clear()
+    public function clear(): bool
     {
         $this->deferredItems = [];
         return $this->doFileCache->flush();
     }
 
-    public function deleteItem($key)
+    public function deleteItem($key): bool
     {
         $this->sanityCheckKey($key);
 
@@ -86,35 +93,52 @@ class CacheItemPool implements CacheItemPoolInterface
         return true;
     }
 
-    public function deleteItems(array $keys)
+    public function deleteItems(array $keys): bool
     {
-
-
-        foreach($keys as $key) {
+        foreach ($keys as $key) {
             $this->deleteItem($key);
         }
 
         return true;
     }
 
-    public function save(CacheItemInterface $item)
+    public function save(CacheItemInterface $item): bool
     {
-        return $this->doFileCache->set($item->getKey(), $item->get(), $item->getExpires());
-    }
-
-    public function saveDeferred(CacheItemInterface $item)
-    {
-        $this->deferredItems[$item->getKey()] = $item->prepareForSaveDeferred();
-        return true;
-    }
-
-    public function commit()
-    {
-        foreach($this->deferredItems as $item) {
-            $this->save($item);
+        if (!$item instanceof CacheItem) {
+            throw new CacheInvalidArgumentException('Only cache items created by this pool can be saved.');
         }
-        $this->deferredItems = [];
+
+        return $this->doFileCache->set(
+            $item->getKey(),
+            [self::VALUE_MARKER => $item->get()],
+            $item->getExpires()
+        );
+    }
+
+    public function saveDeferred(CacheItemInterface $item): bool
+    {
+        if (!$item instanceof CacheItem) {
+            throw new CacheInvalidArgumentException('Only cache items created by this pool can be deferred.');
+        }
+
+        $this->deferredItems[$item->getKey()] = $item->prepareForSaveDeferred();
+
         return true;
+    }
+
+    public function commit(): bool
+    {
+        $success = true;
+
+        foreach ($this->deferredItems as $key => $item) {
+            if ($this->save($item)) {
+                unset($this->deferredItems[$key]);
+            } else {
+                $success = false;
+            }
+        }
+
+        return $success;
     }
 
     public function __destruct()

--- a/tests/Unit/CacheItemPoolTest.php
+++ b/tests/Unit/CacheItemPoolTest.php
@@ -67,6 +67,27 @@ final class CacheItemPoolTest extends TestCase
         $this->assertSame('deferred-value', $fetched->get());
     }
 
+    /**
+     * @dataProvider falseyValues
+     */
+    public function testDeferredCommitPersistsFalseyValues($value): void
+    {
+        $item = $this->pool->getItem('falsey');
+        $item->set($value);
+        $this->pool->saveDeferred($item);
+
+        $this->assertTrue($this->pool->commit());
+
+        $fetched = $this->pool->getItem('falsey');
+        $this->assertTrue($fetched->isHit());
+        $this->assertSame($value, $fetched->get());
+    }
+
+    public function falseyValues(): array
+    {
+        return [[false], [null], [0], ['']];
+    }
+
     public function testInvalidKeyThrowsException(): void
     {
         $this->expectException(CacheInvalidArgumentException::class);


### PR DESCRIPTION
## What changed

- supports `psr/cache` v1, v2, and v3
- adds the required PHP 8.0 floor for the typed PSR interfaces
- preserves cached `false`, `null`, `0`, and empty-string values
- handles integer, `DateInterval`, and null expirations
- rejects foreign cache-item implementations cleanly
- adds a PHP 8.0/8.5 × PSR v1/v2/v3 CI matrix

## Why

This resolves #1 and supersedes #2. The contributor PR identified the compatibility gap, but its deferred-value check dropped falsey values; this version retains the good interface work and fixes that data-loss edge case.

## Validation

- Composer JSON parsed successfully
- `git diff --check` passed
- GitHub Actions exercises all supported PSR majors